### PR TITLE
Enable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hornet
 
- Hornet is a simple library for stress testing.
+Hornet is a simple library for stress testing.
 
 It executes the given function with the given rate (calls per second), dynamically changing the number of processes to maintain the rate.
 
@@ -31,17 +31,20 @@ Hornet.start(params)
 It accepts a keyword list.
 
 Required parameters:
-  - `rate` - the required rate in operations per seconds. For example, 100 (ops/second)
-  - `func` - the anonymous function that has to be executed. For example, `fn -> 1 + 1 end`
-  - `id` - atom that will be used for Hornet's process names.
+
+- `rate` - the required rate in operations per seconds. For example, 100 (ops/second)
+- `func` - the anonymous function that has to be executed. For example, `fn -> 1 + 1 end`
+- `id` - atom that will be used for Hornet's process names.
 
 Optional parameters:
-  - `start_period` - every process executes the given function periodically. This is a starting value for this period. The default value is 100 ms.
-  - `adjust_step` - if the given rate can no be maintained (for example, if the function is executed too long), Hornet will start increasing the number of processes and the execution period for each process. The period will start increasing by `adjust_step`. The default value is 50ms.
-  - `adjust_period` - the number of processes is adjusted periodically by `adjust_period` value. The default value is 5_000 ms.
-  - `error_rate` - allowed rate for difference between the expected rate and the actual rate:  `|current_rate - expected_rate| < error_rate`. The default value is 0.1.
-  - `process_number_limit` - if the given function's execution time is too long and the required rate is high, Hornet will be spawning processes indefinitely. This value will limit the number of processes. The default value is nil.
-  - `rate_period` - the period of measuring the current rate. The default value is 1_000 ms.
+
+- `start_period` - every process executes the given function periodically. This is a starting value for this period. The default value is 100 ms.
+- `adjust_step` - if the given rate can no be maintained (for example, if the function is executed too long), Hornet will start increasing the number of processes and the execution period for each process. The period will start increasing by `adjust_step`. The default value is 50ms.
+- `adjust_period` - the number of processes is adjusted periodically by `adjust_period` value. The default value is 5_000 ms.
+- `error_rate` - allowed rate for difference between the expected rate and the actual rate: `|current_rate - expected_rate| < error_rate`. The default value is 0.1.
+- `process_number_limit` - if the given function's execution time is too long and the required rate is high, Hornet will be spawning processes indefinitely. This value will limit the number of processes. The default value is nil.
+- `rate_period` - the period of measuring the current rate. The default value is 1_000 ms.
+- `log_period` - the interval for the log messages.
 
 To stop Hornet use `Hornet.stop/1`:
 
@@ -62,7 +65,6 @@ It accepts the pid returned by `Hornet.start/1` or the provided id.
 ## Author
 
 Ayrat Badykov (@ayrat555)
-
 
 ## License
 

--- a/lib/hornet/params_validator.ex
+++ b/lib/hornet/params_validator.ex
@@ -8,7 +8,8 @@ defmodule Hornet.ParamsValidator do
     adjust_period: 5_000,
     error_rate: 0.1,
     process_number_limit: nil,
-    rate_period: 1_000
+    rate_period: 1_000,
+    log_period: 0
   }
 
   @spec validate!(Keyword.t()) :: Keyword.t()

--- a/lib/hornet/scheduler.ex
+++ b/lib/hornet/scheduler.ex
@@ -55,7 +55,8 @@ defmodule Hornet.Scheduler do
     {pid, workers_count} = start_workers(supervisor, worker_params, rate_counter, period)
 
     {:ok, adjustment_timer} = :timer.send_interval(adjust_period, :adjust_workers)
-    {:ok, log_timer} = :timer.send_interval(log_period, :log_rates)
+    {:ok, log_timer} = if log_period > 0 do :timer.send_interval(log_period, :log_rates) else {:ok, nil} end
+
 
     state = %{
       rate_counter: rate_counter,
@@ -70,7 +71,7 @@ defmodule Hornet.Scheduler do
       process_number_limit: process_number_limit,
       adjustment_timer: adjustment_timer,
       log_period: log_period,
-      log_timer: log_timer
+      log_timer: log_timer || nil
     }
 
     {:ok, state}

--- a/lib/hornet/scheduler.ex
+++ b/lib/hornet/scheduler.ex
@@ -2,6 +2,7 @@ defmodule Hornet.Scheduler do
   @moduledoc false
 
   use GenServer
+  require Logger
 
   alias Hornet.DynamicSupervisor, as: HornetDynamicSupervisor
   alias Hornet.RateCounter
@@ -49,10 +50,12 @@ defmodule Hornet.Scheduler do
     adjust_period = params[:adjust_period]
     error_rate = params[:error_rate]
     process_number_limit = params[:process_number_limit]
+    log_period = params[:log_period]
 
     {pid, workers_count} = start_workers(supervisor, worker_params, rate_counter, period)
 
-    {:ok, timer} = :timer.send_interval(adjust_period, :adjust_workers)
+    {:ok, adjustment_timer} = :timer.send_interval(adjust_period, :adjust_workers)
+    {:ok, log_timer} = :timer.send_interval(log_period, :log_rates)
 
     state = %{
       rate_counter: rate_counter,
@@ -65,7 +68,9 @@ defmodule Hornet.Scheduler do
       error_rate: error_rate,
       params: worker_params,
       process_number_limit: process_number_limit,
-      timer: timer
+      adjustment_timer: adjustment_timer,
+      log_period: log_period,
+      log_timer: log_timer
     }
 
     {:ok, state}
@@ -83,6 +88,21 @@ defmodule Hornet.Scheduler do
       true ->
         adjust_workers(state)
     end
+  end
+
+  @impl true
+  def handle_info(:log_rates, state) do
+    current_rate = RateCounter.rate(state.rate_counter) |> round()
+    expected_rate = state.params[:rate]
+    error_rate = (expected_rate * state.error_rate) |> round()
+
+    Logger.info(
+      "[Hornet] Current rate: #{current_rate} | Expected rate: #{expected_rate} | Allowed error rate: #{
+        error_rate
+      }"
+    )
+
+    {:noreply, state}
   end
 
   @impl true


### PR DESCRIPTION
Enable logging with a configurable interval.
The scheduler logs some metrics at the given interval. If the interval is 0, the logging is disabled.

Format of log message: 
"[Hornet] Current rate: 1000 | Expected rate: 1000 | Allowed error rate: 100"